### PR TITLE
Fix print() in greentext.py and utils.py

### DIFF
--- a/greentext.py
+++ b/greentext.py
@@ -365,7 +365,7 @@ class Greentext:
                         tokens_group.append(tokens_group.pop()[:-1])    # remove comma from last token
                         result = self.parse_expression(tokens_group)
                         if result is not None:
-                            print result,
+                            print (result),
                         else:
                             error_and_quit("bad expression", self.lc)
                         tokens_group = []
@@ -373,7 +373,7 @@ class Greentext:
                 if len(tokens_group) > 0:
                     result = self.parse_expression(tokens_group)
                     if result is not None:
-                        print result,
+                        print (result),
                     else:
                         error_and_quit("bad expression", self.lc)
                 # print newline

--- a/helloWorld.gt
+++ b/helloWorld.gt
@@ -1,0 +1,4 @@
+# python3 greentext.py < helloWorld.gt
+> be me
+> mfw "Hello World!"
+> thank mr skeltal

--- a/utils.py
+++ b/utils.py
@@ -17,9 +17,9 @@ def is_float(token):
 
 def error_and_quit(message, line_address):
     if line_address == -1:
-        print "wtf:", message
+        print ("wtf:", message)
     else:
-        print "wtf:", message, "at line", line_address + 1
+        print ("wtf:", message, "at line", line_address + 1)
     exit()
 
 


### PR DESCRIPTION
Hi, wanted to try **greentext** with a basic `helloWorld.gt` program.
However, running `python3 greentext < helloWorld.gt` returned the following error message:
> File ".../greentext/greentext.py", line 368
> print result,
> SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?

Therefore fixed the function `print()` in both `greentext.py` and `utils.py` to include the parenthesis.
Now `helloWorld.gt` works like a charm. Thought it was a good idea to include it in the repo but that doesn't really matter :^)